### PR TITLE
feature/#17-refactor idempotent tasks

### DIFF
--- a/src/notifications/celery.py
+++ b/src/notifications/celery.py
@@ -77,12 +77,15 @@ class Task(_Task):
         self,
         args: Sequence[Any] | None = None, kwargs: dict[str, Any] | None = None, *,
         force: bool = False,
+        lock_ttl: seconds | None = None,
         **options,
     ) -> AsyncResult | None:
         if args is None:
             args = ()
         if kwargs is None:
             kwargs = {}
+        if lock_ttl is not None:
+            self.lock_ttl = lock_ttl
         if not self.lock_ttl or "chunk" in kwargs:
             return super().apply_async(args=args, kwargs=kwargs, **options)
         lock_key = self.get_lock_key(args, kwargs)

--- a/src/notifications/containers.py
+++ b/src/notifications/containers.py
@@ -8,9 +8,7 @@ from dependency_injector import containers, providers
 from notifications.core.config import get_settings
 from notifications.core.logging import configure_logger
 from notifications.domain import messages, periodic_tasks, templates
-from notifications.domain.factories import base_key_factory
 from notifications.infrastructure.db import cache, postgres, redis, repositories
-from notifications.infrastructure.db.cache import CacheKeyBuilder
 from notifications.infrastructure.emails.clients import ConsoleClient
 from notifications.infrastructure.emails.stubs import StreamStub
 from notifications.integrations.auth.stubs import NetflixAuthClientStub
@@ -103,15 +101,6 @@ class Container(containers.DeclarativeContainer):
         NetflixUgcClientStub,
     )
 
-    # Domain -> Common
-
-    cache_key_builder = providers.Singleton(CacheKeyBuilder)
-    base_key_factory_ = providers.Callable(
-        base_key_factory,
-        key_builder=cache_key_builder,
-        min_length=config.CACHE_HASHED_KEY_LENGTH,
-    )
-
     # Domain -> Templates
 
     template_repository = providers.Singleton(
@@ -130,8 +119,6 @@ class Container(containers.DeclarativeContainer):
         messages.EmailNotificationService,
         email_client=email_client,
         template_service=template_service,
-        key_factory=base_key_factory_.provider,
-        cache_client=cache_client,
     )
 
     notification_dispatcher_service = providers.Singleton(
@@ -155,8 +142,6 @@ class Container(containers.DeclarativeContainer):
         template_service=template_service,
         auth_client=auth_client,
         ugc_client=ugc_client,
-        key_factory=base_key_factory_.provider,
-        cache_client=cache_client,
     )
 
 

--- a/src/notifications/domain/factories.py
+++ b/src/notifications/domain/factories.py
@@ -1,9 +1,0 @@
-from notifications.infrastructure.db.cache import CacheKeyBuilder
-
-
-def base_key_factory(key_builder: CacheKeyBuilder, min_length: int, *args, **kwargs) -> str:
-    """Фабрика по созданию ключей для кэша."""
-    base_key: str = kwargs.pop("base_key")
-    prefix: str | None = kwargs.pop("prefix", None)
-    suffix: str | None = kwargs.pop("suffix", None)
-    return key_builder.make_key(base_key, min_length=min_length, prefix=prefix, suffix=suffix)

--- a/src/notifications/domain/messages/exceptions.py
+++ b/src/notifications/domain/messages/exceptions.py
@@ -9,3 +9,11 @@ class InvalidNotificationTypeError(NetflixNotificationsError):
     message = "Notification type is invalid"
     code = "invalid_notification_type"
     status_code: int = HTTPStatus.BAD_REQUEST
+
+
+class NotificationCooldownError(NetflixNotificationsError):
+    """Кулдаун отправки уведомлений."""
+
+    message = "Notification service is in cooldown, try to send a request later"
+    code = "notification_cooldown"
+    status_code = HTTPStatus.REQUEST_TIMEOUT

--- a/src/notifications/domain/messages/services.py
+++ b/src/notifications/domain/messages/services.py
@@ -1,12 +1,10 @@
 from __future__ import annotations
 
 import datetime
-import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from notifications.domain.templates import TemplateService
-from notifications.infrastructure.db.cache import BaseCache
 from notifications.infrastructure.emails.clients import BaseEmailClient, EmailMessageDetail
 
 from .types import NotificationPayload
@@ -25,16 +23,6 @@ class BaseNotificationService(ABC):
     @abstractmethod
     async def send_message(self, message_payload: NotificationPayload, /) -> int:
         """Отправка уведомления пользователю."""
-
-    @abstractmethod
-    async def send_message_idempotently(
-        self, message_payload: NotificationPayload, /, *, ttl: seconds | datetime.timedelta | None = None,
-    ) -> int:
-        """Идемпотентная отправка уведомления пользователю.
-
-        Пользователю не может отправиться уведомление с одинаковым заголовком из `message_payload`
-        в течение `ttl` или `DEFAULT_NOTIFICATION_LOCK`.
-        """
 
     @abstractmethod
     async def build_message_from_payload(self, payload: NotificationPayload, /) -> EmailMessageDetail:
@@ -59,48 +47,16 @@ class EmailNotificationService(BaseNotificationService):
 
     DEFAULT_NOTIFICATION_LOCK = datetime.timedelta(hours=1)
 
-    def __init__(
-        self,
-        email_client: BaseEmailClient, template_service: TemplateService,
-        key_factory: Callable[..., str], cache_client: BaseCache,
-    ) -> None:
+    def __init__(self, email_client: BaseEmailClient, template_service: TemplateService) -> None:
         assert isinstance(email_client, BaseEmailClient)
         self._email_client = email_client
 
         assert isinstance(template_service, TemplateService)
         self._template_service = template_service
 
-        assert callable(key_factory)
-        self._key_factory = key_factory
-
-        assert isinstance(cache_client, BaseCache)
-        self._cache_client = cache_client
-
     async def send_message(self, message_payload: NotificationPayload, /) -> int:
         message = await self.build_message_from_payload(message_payload)
         return self._email_client.send_messages((message,))
-
-    async def send_message_idempotently(
-        self, message_payload: NotificationPayload, /, *,
-        ttl: seconds | datetime.timedelta | None = None,
-        force: bool = False,
-    ) -> int:
-        if not message_payload["recipient_list"]:
-            return 0
-        if ttl is None:
-            ttl = self.DEFAULT_NOTIFICATION_LOCK
-        subject = message_payload["subject"]
-        email = message_payload["recipient_list"][0]
-        key = self._key_factory(base_key=subject, prefix=f"messages:template:{email}:")
-        if force:
-            logging.debug(f"force=True, ignoring [{key}]")
-            await self._cache_client.set(key, email, ttl=ttl)
-            return await self.send_message(message_payload)
-        elif not await self._cache_client.set(key, email, ttl=ttl, create_missing=False):
-            logging.debug(f"[{key}] is locked. Email has been already sent.")
-            return 0
-        logging.debug(f"[{key}] has been acquired")
-        return await self.send_message(message_payload)
 
     async def build_message_from_payload(self, payload: NotificationPayload, /) -> EmailMessageDetail:
         content = await self._get_message_content_from_payload(payload)

--- a/src/notifications/domain/messages/tasks.py
+++ b/src/notifications/domain/messages/tasks.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
     default_retry_delay=5,
     autoretry_for=(SoftTimeLimitExceeded,),
     expires=datetime.datetime.now(TZ_MOSCOW) + datetime.timedelta(hours=12),
+    lock_ttl=5 * 60,
+    lock_suffix=lambda notification: ("email", notification["recipient_list"][0], "subject", notification["subject"]),
 )
 @sync_task
 @inject

--- a/src/notifications/domain/messages/tasks.py
+++ b/src/notifications/domain/messages/tasks.py
@@ -31,12 +31,11 @@ if TYPE_CHECKING:
 async def send_email(
     self: Task,
     notification: NotificationPayload, *args,
-    force: bool = False,
     email_service: EmailNotificationService = Provide[Container.email_notification_service],
     **kwargs,
 ) -> None:
     """Фоновая задача по отправке уведомления на почту."""
-    await email_service.send_message_idempotently(notification, force=force)
+    await email_service.send_message(notification)
     self.log.info("Notification has been sent.")
 
 

--- a/src/notifications/domain/periodic_tasks/enums.py
+++ b/src/notifications/domain/periodic_tasks/enums.py
@@ -5,3 +5,9 @@ class DefaultTemplateSlugs(str, Enum):
     """Слаги шаблонов по умолчанию."""
 
     WEEKLY_DIGEST = "_notifications-weekly_digest"
+
+
+class NotificationSubject(str, Enum):
+    """Заголовки уведомлений."""
+
+    WEEKLY_DIGEST = "Еженедельный дайджест"

--- a/src/notifications/domain/periodic_tasks/tasks.py
+++ b/src/notifications/domain/periodic_tasks/tasks.py
@@ -16,6 +16,7 @@ from notifications.integrations.auth.enums import DefaultRoles
 from notifications.integrations.auth.types import BoundaryRegistrationDate, UserDetail
 
 from .constants import PERIODIC_TASK_PREFIX
+from .enums import NotificationSubject
 from .types import UserPayload
 
 if TYPE_CHECKING:
@@ -58,6 +59,10 @@ get_subscribers_initial_chunk = partial(get_users_initial_chunk, user_role=Defau
     default_retry_delay=5,
     autoretry_for=(SoftTimeLimitExceeded,),
     expires=datetime.datetime.now(TZ_MOSCOW) + datetime.timedelta(hours=12),
+    lock_ttl=12 * 60 * 60,
+    lock_suffix=(
+        lambda user_payload: ("email", user_payload["email"], "subject", NotificationSubject.WEEKLY_DIGEST.value)
+    ),
 )
 @sync_task
 @inject


### PR DESCRIPTION
Closes #17 

- Отрефакторил реализацию идемпотентных задачах - теперь используется стандартный механизм `Task.lock_suffix` из переопределенной Celery задачи